### PR TITLE
use mailmap to merge mathlib contributors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,23 @@ jobs:
     - name: Checkout mathlib
       run: git clone https://github.com/leanprover-community/mathlib
 
+    - name: Checkout mathlib-mailmap
+      uses: actions/checkout@v2
+      with:
+        # this repo is private to prevent spambots from scraping email addresses
+        repository: leanprover-community/mathlib-mailmap
+        token: ${{ secrets.MAILMAP_GITHUB_TOKEN }}
+        path: mailmap
+
     - name: install Python
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
 
     - name: Run gitstats
-      run: ./gitstats.py mathlib docs
+      run: |
+        cp mailmap/mailmap mathlib/.mailmap
+        ./gitstats.py mathlib docs
 
     - name: Install gnuplot
       run: sudo apt-get install gnuplot


### PR DESCRIPTION
Inspired by [this Zulip message](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/New.20website/near/197217531), I made a cleaned up `.mailmap` file for mathlib and put it in a private repository (to prevent spambot scraping). This PR incorporates that mailmap into the generation of statistics.