### PR TITLE
Add row numbering to mathlib_stats table

### DIFF
--- a/gitstats.py
+++ b/gitstats.py
@@ -809,6 +809,7 @@ function sort_age(a, b, rowA, rowB) {
 """)
         ### Authors
         data_file.write('authors_cols = ['
+                '{formatter: "rownum", width: 40 },'
                 '{title: "Author", field: "Author"},'
                 '{title: "Commits (%)", field: "Commits (%)", sorter: sort_commits},'
                 '{title: "+ lines", field: "+ lines"},'
@@ -817,8 +818,7 @@ function sort_age(a, b, rowA, rowB) {
                 '{title: "Last commit", field: "Last commit"},'
                 '{title: "Age", field: "Age", sorter: sort_age},'
                 '{title: "age_seconds", field: "age_seconds", visible: false},'
-                '{title: "Active days", field: "Active days"},'
-                '{title: "# by commits", field: "# by commits"}]\n')
+                '{title: "Active days", field: "Active days"}]\n')
         authors = []
         for id_, author in enumerate(data.getAuthors()):
             if author == 'leanprover-community-bot':
@@ -833,8 +833,7 @@ function sort_age(a, b, rowA, rowB) {
                     'Last commit': info['date_last'],
                     'Age': str(info['timedelta']),
                     'age_seconds': info['age_seconds'],
-                    'Active days': len(info['active_days']),
-                    '# by commits': info['place_by_commits']}
+                    'Active days': len(info['active_days'])}
             authors.append(row)
         data_file.write(f'authors = {json.dumps(authors)}\n')
 


### PR DESCRIPTION
In addition to fixing #5, part of the motivation is discussed in with [this thread](https://leanprover.zulipchat.com/#narrow/stream/113488-general/topic/mathlib.20stats/near/289331098). Adding a column of values that doesn't change when you sort by other columns lets you see the rankings for those other columns. For example, sorting by "+ lines" will now let you see where you stand in terms of the number of lines you've contributed.

Another side benefit is that is seems this new column is made a bit narrower by default, so the rest of the columns can become a bit more spacious.

Fixes #5.